### PR TITLE
[DC-2043] Break sending large webhook payload

### DIFF
--- a/errors/oversize_break_error.go
+++ b/errors/oversize_break_error.go
@@ -1,0 +1,21 @@
+package errors
+
+import (
+	"fmt"
+
+	aws_extended_sqsiface "github.com/shoplineapp/aws-sqs-golang-extended-client-lib/interfaces"
+)
+
+type OversizeBreakError struct {
+	aws_extended_sqsiface.ErrorInterface
+	Message string
+	Size    int
+}
+
+func (e OversizeBreakError) Code() string {
+	return "AwsSqsGoExtendedClientOversizeBreakError"
+}
+
+func (e OversizeBreakError) Error() string {
+	return fmt.Sprintf("%s - %s", e.Code(), e.Message)
+}

--- a/interfaces/aws_extended_sqs_client_configuration.go
+++ b/interfaces/aws_extended_sqs_client_configuration.go
@@ -6,6 +6,7 @@ import (
 
 type AwsExtendedSqsClientConfigurationInterface interface {
 	WithPayloadSupportEnabled(s3 aws_s3iface.S3API, s3BucketName string)
+	WithBreakSendSupportEnabled()
 	SetPayloadSizeThreshold(threshold int)
 	SetBreakSendPayloadSizeThreshold(threshold int)
 	SetAlwaysThroughS3(alwaysThroughS3 bool)

--- a/interfaces/aws_extended_sqs_client_configuration.go
+++ b/interfaces/aws_extended_sqs_client_configuration.go
@@ -7,10 +7,13 @@ import (
 type AwsExtendedSqsClientConfigurationInterface interface {
 	WithPayloadSupportEnabled(s3 aws_s3iface.S3API, s3BucketName string)
 	SetPayloadSizeThreshold(threshold int)
+	SetBreakSendPayloadSizeThreshold(threshold int)
 	SetAlwaysThroughS3(alwaysThroughS3 bool)
 	SetCleanupS3Payload(cleanupS3Payload bool)
 	IsPayloadSupportEnabled() bool
+	IsBreakSendSupportEnabled() bool
 	GetPayloadSizeThreshold() int
+	GetBreakSendPayloadSizeThreshold() int
 	IsAlwaysThroughS3() bool
 	DoesCleanupS3Payload() bool
 }

--- a/services/aws_extended_sqs_client/aws_extended_sqs_client.go
+++ b/services/aws_extended_sqs_client/aws_extended_sqs_client.go
@@ -310,7 +310,7 @@ func (c *AwsExtendedSQSClient) getMessageDestination(input *aws_sqs.SendMessageI
 	if c.config.IsBreakSendSupportEnabled() && bodySize > c.config.GetBreakSendPayloadSizeThreshold() {
 		errorMessage := fmt.Sprintf("Total size of message is %s, exceeds the maximum allowed. Message send process is breaked.", strconv.Itoa(totalSize))
 
-		logger.WithField("method", "getMessageDestination").Errorf("Error: %+v\n", errorMessage)
+		logger.WithFields(logrus.Fields{"method": "getMessageDestination", "message_size": strconv.Itoa(totalSize)}).Errorf("Error: %+v\n", errorMessage)
 
 		return "", errors.OversizeBreakError{Message: errorMessage, Size: totalSize}
 	} else if totalSize > c.config.GetPayloadSizeThreshold() {

--- a/services/aws_extended_sqs_client/aws_extended_sqs_client.go
+++ b/services/aws_extended_sqs_client/aws_extended_sqs_client.go
@@ -308,11 +308,11 @@ func (c *AwsExtendedSQSClient) getMessageDestination(input *aws_sqs.SendMessageI
 	logger.WithField("message_size", strconv.Itoa(totalSize)).Infoln("Calculated payload size")
 
 	if c.config.IsBreakSendSupportEnabled() && bodySize > c.config.GetBreakSendPayloadSizeThreshold() {
-		errorMessage := fmt.Sprintf("Total size of message is %s, exceeds the maximum allowed. Message send process is breaked.")
+		errorMessage := fmt.Sprintf("Total size of message is %s, exceeds the maximum allowed. Message send process is breaked.", strconv.Itoa(totalSize))
 
 		logger.WithField("method", "getMessageDestination").Errorf("Error: %+v\n", errorMessage)
 
-		return "", errors.SDKError{Message: errorMessage}
+		return "", errors.OversizeBreakError{Message: errorMessage, Size: totalSize}
 	} else if totalSize > c.config.GetPayloadSizeThreshold() {
 		return "s3", nil
 	}

--- a/services/aws_extended_sqs_client/aws_extended_sqs_client.go
+++ b/services/aws_extended_sqs_client/aws_extended_sqs_client.go
@@ -84,14 +84,15 @@ func (c *AwsExtendedSQSClient) SendMessage(input *aws_sqs.SendMessageInput) (*aw
 		return c.SQSAPI.SendMessage(input)
 	}
 
-	if err := c.checkMessageAttributes(input.MessageAttributes); err != nil {
-		logger.WithField("method", "checkMessageAttributes").Errorf("Error: %+v\n", err)
+	destination, err := c.getMessageDestination(input, logger)
+	if err != nil {
 		return &aws_sqs.SendMessageOutput{}, err
 	}
 
 	var sqsInput *aws_sqs.SendMessageInput
 
-	if c.config.IsAlwaysThroughS3() || c.isLarge(input, logger) {
+	switch destination {
+	case "s3":
 		var err error
 		sqsInput, err = c.storeMessageInS3(input)
 
@@ -101,10 +102,16 @@ func (c *AwsExtendedSQSClient) SendMessage(input *aws_sqs.SendMessageInput) (*aw
 		}
 
 		logger.WithField("uploaded_to_s3", "true").Infoln("Uploaded to s3")
-	} else {
+		break
+	case "sqs":
 		logger.WithField("uploaded_to_s3", "false").Infoln("Handled by original sqs sdk")
 
 		sqsInput = input
+		break
+	default:
+		errorMessage := "Unknown message destination"
+		logger.WithField("destination", destination).Errorln(errorMessage)
+		return &aws_sqs.SendMessageOutput{}, errors.SDKError{Message: errorMessage}
 	}
 
 	return c.SQSAPI.SendMessage(sqsInput)
@@ -259,8 +266,7 @@ func (c *AwsExtendedSQSClient) DeleteMessage(input *aws_sqs.DeleteMessageInput) 
 	return c.SQSAPI.DeleteMessage(modifiedInput)
 }
 
-func (c *AwsExtendedSQSClient) checkMessageAttributes(attributes map[string]*aws_sqs.MessageAttributeValue) error {
-	attributeSize := getMsgAttributesSize(attributes)
+func (c *AwsExtendedSQSClient) checkMessageAttributes(attributes map[string]*aws_sqs.MessageAttributeValue, attributeSize int) error {
 	sizeThreshold := c.config.GetPayloadSizeThreshold()
 	if attributeSize > sizeThreshold {
 		errorMessage := fmt.Sprintf("Total size of Message attributes is %s bytes which is larger than the threshold of %s Bytes. Consider including the payload in the message body instead of message attributes.", strconv.Itoa(attributeSize), strconv.Itoa(sizeThreshold))
@@ -285,15 +291,33 @@ func (c *AwsExtendedSQSClient) checkMessageAttributes(attributes map[string]*aws
 	return nil
 }
 
-func (c *AwsExtendedSQSClient) isLarge(input *aws_sqs.SendMessageInput, logger logrus.FieldLogger) bool {
+func (c *AwsExtendedSQSClient) getMessageDestination(input *aws_sqs.SendMessageInput, logger logrus.FieldLogger) (string, error) {
 	attributeSize := getMsgAttributesSize(input.MessageAttributes)
-	bodySize := len(*input.MessageBody)
+	if err := c.checkMessageAttributes(input.MessageAttributes, attributeSize); err != nil {
+		logger.WithField("method", "checkMessageAttributes").Errorf("Error: %+v\n", err)
+		return "", err
+	}
 
+	if c.config.IsAlwaysThroughS3() {
+		return "s3", nil
+	}
+
+	bodySize := len(*input.MessageBody)
 	totalSize := attributeSize + bodySize
 
 	logger.WithField("message_size", strconv.Itoa(totalSize)).Infoln("Calculated payload size")
 
-	return totalSize > c.config.GetPayloadSizeThreshold()
+	if c.config.IsBreakSendSupportEnabled() && bodySize > c.config.GetBreakSendPayloadSizeThreshold() {
+		errorMessage := fmt.Sprintf("Total size of message is %s, exceeds the maximum allowed. Message send process is breaked.")
+
+		logger.WithField("method", "getMessageDestination").Errorf("Error: %+v\n", errorMessage)
+
+		return "", errors.SDKError{Message: errorMessage}
+	} else if totalSize > c.config.GetPayloadSizeThreshold() {
+		return "s3", nil
+	}
+
+	return "sqs", nil
 }
 
 func (c *AwsExtendedSQSClient) storeMessageInS3(input *aws_sqs.SendMessageInput) (*aws_sqs.SendMessageInput, error) {

--- a/services/aws_extended_sqs_client/aws_extended_sqs_client_configuration.go
+++ b/services/aws_extended_sqs_client/aws_extended_sqs_client_configuration.go
@@ -16,16 +16,21 @@ type AwsExtendedSQSClientConfiguration struct {
 	payloadSizeThreshold int
 	alwaysThroughS3      bool
 	cleanupS3Payload     bool
+
+	breakSendSupport              bool
+	breakSendPayloadSizeThreshold int
 }
 
 func NewExtendedSQSClientConfiguration() *AwsExtendedSQSClientConfiguration {
 	return &AwsExtendedSQSClientConfiguration{
-		s3:                   nil,
-		s3BucketName:         "",
-		payloadSupport:       false,
-		payloadSizeThreshold: sqs_configs_constants.DEFAULT_MESSAGE_SIZE_THRESHOLD,
-		alwaysThroughS3:      false,
-		cleanupS3Payload:     true,
+		s3:                            nil,
+		s3BucketName:                  "",
+		payloadSupport:                false,
+		payloadSizeThreshold:          sqs_configs_constants.DEFAULT_MESSAGE_SIZE_THRESHOLD,
+		alwaysThroughS3:               false,
+		cleanupS3Payload:              true,
+		breakSendSupport:              false,
+		breakSendPayloadSizeThreshold: sqs_configs_constants.DEFAULT_BREAK_SEND_MESSAGE_SIZE_THRESHOLD,
 	}
 }
 
@@ -33,6 +38,10 @@ func (config *AwsExtendedSQSClientConfiguration) WithPayloadSupportEnabled(s3 aw
 	config.s3 = s3
 	config.s3BucketName = s3BucketName
 	config.payloadSupport = true
+}
+
+func (config *AwsExtendedSQSClientConfiguration) WithBreakSendSupportEnabled() {
+	config.breakSendSupport = true
 }
 
 func (config *AwsExtendedSQSClientConfiguration) SetPayloadSizeThreshold(threshold int) {

--- a/services/aws_extended_sqs_client/aws_extended_sqs_client_configuration.go
+++ b/services/aws_extended_sqs_client/aws_extended_sqs_client_configuration.go
@@ -48,6 +48,10 @@ func (config *AwsExtendedSQSClientConfiguration) SetPayloadSizeThreshold(thresho
 	config.payloadSizeThreshold = threshold
 }
 
+func (config *AwsExtendedSQSClientConfiguration) SetBreakSendPayloadSizeThreshold(threshold int) {
+	config.breakSendPayloadSizeThreshold = threshold
+}
+
 func (config *AwsExtendedSQSClientConfiguration) SetAlwaysThroughS3(alwaysThroughS3 bool) {
 	config.alwaysThroughS3 = alwaysThroughS3
 }
@@ -60,8 +64,16 @@ func (config *AwsExtendedSQSClientConfiguration) IsPayloadSupportEnabled() bool 
 	return config.payloadSupport
 }
 
+func (config *AwsExtendedSQSClientConfiguration) IsBreakSendSupportEnabled() bool {
+	return config.breakSendSupport
+}
+
 func (config *AwsExtendedSQSClientConfiguration) GetPayloadSizeThreshold() int {
 	return config.payloadSizeThreshold
+}
+
+func (config *AwsExtendedSQSClientConfiguration) GetBreakSendPayloadSizeThreshold() int {
+	return config.breakSendPayloadSizeThreshold
 }
 
 func (config *AwsExtendedSQSClientConfiguration) IsAlwaysThroughS3() bool {

--- a/services/aws_extended_sqs_client/constants/sqs_configs.go
+++ b/services/aws_extended_sqs_client/constants/sqs_configs.go
@@ -1,10 +1,11 @@
 package sqs_configs_constants
 
 const (
-	RESERVED_ATTRIBUTE_NAME        = "ExtendedPayloadSize"
-	LEGACY_RESERVED_ATTRIBUTE_NAME = "SQSLargePayloadSize"
-	MAX_ALLOWED_ATTRIBUTES         = 10 - 1
-	DEFAULT_MESSAGE_SIZE_THRESHOLD = 262144
-	S3_BUCKET_NAME_MARKER          = "-..s3BucketName..-"
-	S3_KEY_MARKER                  = "-..s3Key..-"
+	RESERVED_ATTRIBUTE_NAME                   = "ExtendedPayloadSize"
+	LEGACY_RESERVED_ATTRIBUTE_NAME            = "SQSLargePayloadSize"
+	MAX_ALLOWED_ATTRIBUTES                    = 10 - 1
+	DEFAULT_MESSAGE_SIZE_THRESHOLD            = 262144
+	DEFAULT_BREAK_SEND_MESSAGE_SIZE_THRESHOLD = 10485760
+	S3_BUCKET_NAME_MARKER                     = "-..s3BucketName..-"
+	S3_KEY_MARKER                             = "-..s3Key..-"
 )

--- a/tests/services/aws_extended_sqs_client/aws_extended_sqs_client_test.go
+++ b/tests/services/aws_extended_sqs_client/aws_extended_sqs_client_test.go
@@ -298,7 +298,7 @@ func (s *ExtendedSqsClientTestSuite) Test_ExtendedSqsClient_SendMessage_Failed_M
 
 	assert.NotNil(s.T(), err)
 
-	serr, ok := err.(errors.SDKError)
+	serr, ok := err.(errors.OversizeBreakError)
 	assert.Equal(s.T(), true, ok)
 	assert.Equal(s.T(), true, strings.Contains(serr.Message, "Message send process is breaked"))
 }


### PR DESCRIPTION
- Add break send support function in extended client, with the same approach as S3 support
- Add new error type to expose oversized message size
- Refactor message send destination switching